### PR TITLE
FST Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# NLP Autumn 2022 Homework 3
+# NLP Autumn 202333 Homework 3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# NLP Autumn 202333 Homework 3
+# NLP Autumn 2023 Homework 3

--- a/rayuela/base/semiring.py
+++ b/rayuela/base/semiring.py
@@ -44,6 +44,8 @@ class Semiring:
         raise NotImplementedError
 
     def __eq__(self, other):
+        if not isinstance(other, Semiring):
+            return False
         return self.score == other.score
 
     def __hash__(self):
@@ -79,6 +81,8 @@ class Boolean(Semiring):
         return Boolean.one
 
     def __eq__(self, other):
+        if not isinstance(other, Boolean):
+            return False
         return self.score == other.score
 
     def __lt__(self, other):
@@ -135,6 +139,8 @@ class String(Semiring):
         return String(self.score[len(prefix) :])
 
     def __eq__(self, other):
+        if not isinstance(other, String):
+            return False
         return self.score == other.score
 
     def __repr__(self):
@@ -244,6 +250,8 @@ class Real(Semiring):
         return f"{round(self.score, 15)}"
 
     def __eq__(self, other):
+        if not isinstance(other, Real):
+            return False
         # return float(self.score) == float(other.score)
         return np.allclose(float(self.score), float(other.score), atol=1e-3)
 
@@ -283,6 +291,8 @@ class ProductSemiring(Semiring):
         return ProductSemiring(~self.score[0], ~self.score[1])
 
     def __eq__(self, other):
+        if not isinstance(other, ProductSemiring):
+            return False
         return self.score == other.score
 
     def __repr__(self):

--- a/rayuela/fsa/fsa.py
+++ b/rayuela/fsa/fsa.py
@@ -50,6 +50,21 @@ class FSA:
         # final weight function
         self.ρ = R.chart()
 
+    @property
+    def delta(self):
+        """ASCII shorthand property for self.δ"""
+        return self.δ
+
+    @property
+    def lambda_(self):
+        """ASCII shorthand property for self.λ"""
+        return self.λ
+
+    @property
+    def rho(self):
+        """ASCII shorthand property for self.ρ"""
+        return self.ρ
+
     def add_state(self, q):
         self.Q.add(q)
 

--- a/rayuela/fsa/fst.py
+++ b/rayuela/fsa/fst.py
@@ -36,7 +36,7 @@ class FST(FSA):
         super().__init__(R=R)
 
         # alphabet of output symbols
-        self.Delta = set()
+        self.Omega = set()
 
     def add_arc(self, i, a, b, j, w=None):
         if w is None: w = self.R.one
@@ -49,7 +49,7 @@ class FST(FSA):
 
         self.add_states([i, j])
         self.Sigma.add(a)
-        self.Delta.add(b)
+        self.Omega.add(b)
         self.δ[i][(a, b)][j] += w
 
     def set_arc(self, i, a, b, j, w=None):
@@ -63,12 +63,12 @@ class FST(FSA):
 
         self.add_states([i, j])
         self.Sigma.add(a)
-        self.Delta.add(b)
+        self.Omega.add(b)
         self.δ[i][(a, b)][j] = w
 
     def freeze(self):
         self.Sigma = frozenset(self.Sigma)
-        self.Delta = frozenset(self.Delta)
+        self.Omega = frozenset(self.Omega)
         self.Q = frozenset(self.Q)
         self.δ = frozendict(self.δ)
         self.λ = frozendict(self.λ)


### PR DESCRIPTION
Hello, while working on assignment 3 I found a few things that can be improved in the current code for assignment 3. I am making this pull request so you can merge it if you want, or reject it if you don't want the changes. It's mostly quality-of-life improvements.

**Changes:**

- Check type of `other` argument in `Semiring.__eq__` as otherwise expressions like `Log(1.0) == 0.0` throw an exception. With the proposed changed, this would just return `False` (as expected)
- Rename the FST output alphabet from `Delta` to `Omega`. This servers two purposes:
  1. Stay consistent with the lecture slides, where the output alphabet is denoted by $\Omega$, and
  2. Avoid confusion about `FST.Delta` vs `FST.δ`
- Add ASCII shorthand properties for `FST.δ` (`FST.delta`), `FST.λ` (`FST.lambda_`, as `lambda` is a Python keyword), and `FST.ρ` (`FST.rho`). This doesn't break any existing code and facilitates typing these property names in code editors without having to resort to Unicode characters.

I suggest merging this after the submission deadline on Jan 15th as there are some breaking changes (`FST.Omega`).