### PR TITLE
FST Structural Equality Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# NLP Autumn 2022 Homework 3
+# NLP Autumn 202333 Homework 3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# NLP Autumn 202333 Homework 3
+# NLP Autumn 2023 Homework 3

--- a/rayuela/base/semiring.py
+++ b/rayuela/base/semiring.py
@@ -44,6 +44,8 @@ class Semiring:
         raise NotImplementedError
 
     def __eq__(self, other):
+        if not isinstance(other, Semiring):
+            return False
         return self.score == other.score
 
     def __hash__(self):
@@ -79,6 +81,8 @@ class Boolean(Semiring):
         return Boolean.one
 
     def __eq__(self, other):
+        if not isinstance(other, Boolean):
+            return False
         return self.score == other.score
 
     def __lt__(self, other):
@@ -135,6 +139,8 @@ class String(Semiring):
         return String(self.score[len(prefix) :])
 
     def __eq__(self, other):
+        if not isinstance(other, String):
+            return False
         return self.score == other.score
 
     def __repr__(self):
@@ -244,6 +250,8 @@ class Real(Semiring):
         return f"{round(self.score, 15)}"
 
     def __eq__(self, other):
+        if not isinstance(other, Real):
+            return False
         # return float(self.score) == float(other.score)
         return np.allclose(float(self.score), float(other.score), atol=1e-3)
 
@@ -283,6 +291,8 @@ class ProductSemiring(Semiring):
         return ProductSemiring(~self.score[0], ~self.score[1])
 
     def __eq__(self, other):
+        if not isinstance(other, ProductSemiring):
+            return False
         return self.score == other.score
 
     def __repr__(self):

--- a/rayuela/fsa/fsa.py
+++ b/rayuela/fsa/fsa.py
@@ -50,6 +50,21 @@ class FSA:
         # final weight function
         self.ρ = R.chart()
 
+    @property
+    def delta(self):
+        """ASCII shorthand property for self.δ"""
+        return self.δ
+
+    @property
+    def lambda_(self):
+        """ASCII shorthand property for self.λ"""
+        return self.λ
+
+    @property
+    def rho(self):
+        """ASCII shorthand property for self.ρ"""
+        return self.ρ
+
     def add_state(self, q):
         self.Q.add(q)
 

--- a/rayuela/fsa/fsa_testing.py
+++ b/rayuela/fsa/fsa_testing.py
@@ -1,0 +1,203 @@
+"""
+Functions for correctness testing on WFSAs and WFSTs.
+"""
+import textwrap
+from collections import defaultdict
+
+from tabulate import tabulate
+
+from rayuela.fsa.fsa import FSA
+from rayuela.fsa.fst import FST
+
+
+class _FSAStructuralEqualityReport:
+    """
+    Formats the result of `report_fst_structural_equality` as a table.
+    """
+
+    def __init__(
+        self, report_sections: dict[list], title: str = None, maxwidth: int = 80
+    ):
+        """Creates a report formatter.
+
+        Args:
+            report_sections (dict[list]): Dict of report sections. Keys are section
+                titles and values are lists of strings.
+            title (str, optional): Report title. Defaults to None.
+            maxwidth (int, optional): Maximum cell width. Defaults to 80.
+        """
+        self.report_sections = report_sections
+        self.title = title
+        self.maxwidth = maxwidth
+
+    @property
+    def structurally_equal(self):
+        """
+        Returns True if the two FSTs are structurally equal, False otherwise.
+        """
+        return len(self.report_sections) == 0
+
+    def __str__(self):
+        rows = []
+        if len(self.report_sections) == 0:
+            rows.append(["FSTs are structurally equal"])
+        for key, values in self.report_sections.items():
+            # Make key more readable
+            key = key.replace("_", " ").capitalize()
+            # Make sure that string width does not exceed 80 characters
+            values = [
+                textwrap.fill(value, width=self.maxwidth, subsequent_indent="    ")
+                for value in values
+            ]
+            rows.extend([[key], ["\n".join(values)]])
+        return tabulate(
+            rows,
+            headers=[self.title or "FST Structural Equality Report"],
+            tablefmt="grid",
+        )
+
+    def __repr__(self):
+        return str(self)
+
+    def __eq__(self, other):
+        if not isinstance(other, _FSAStructuralEqualityReport):
+            return False
+        return set(self.report_sections.keys()) == set(
+            other.report_sections.keys()
+        ) and all(
+            set(self.report_sections[key]) == set(other.report_sections[key])
+            for key in self.report_sections.keys()
+        )
+
+
+def _arcs(fst: FSA | FST):
+    """
+    Returns a list of all arcs in the FST in the format (i, (a, b), j, w)
+
+    Args:
+        fst (FSA | FST): FSA or FST to get arcs from. If FSA, ab is just the symbol a.
+            If FST, ab is the pair (a, b).
+    """
+    return {
+        (i, ab, j, w)
+        for i, ab_j_w in fst.δ.items()
+        for ab, j_w in ab_j_w.items()
+        for j, w in j_w.items()
+    }
+
+
+def fsa_structural_equality_report(fsa1: FSA | FST, fsa2: FSA | FST, title=None):
+    """
+    Returns a detailed report on structural differences between two WFSAs. Two WFSAs are
+    considered structurally equal, if
+
+    - They have the same semiring
+    - They have the same input (and output, if FST) alphabet
+    - They have the same set of states
+    - Initial and final weight functions are functionally equal (i.e. agree on every
+      state)
+    - They have the same set of arcs, and the weight function is functionally equal
+      (i.e. agree on every arc)
+
+    Other quantities such as FSA.I and FSA.F are not checked, as they are derived from
+    the above.
+
+    Args:
+        fsa1 (FSA | FST): First FSA
+        fsa2 (FSA | FST): Second FSA
+        title (str, optional): Title of the report. Defaults to None.
+
+    Returns:
+        _FSAStructuralEqualityReport: Report object. Can be printed or converted to
+            string.
+    """
+    mismatches = defaultdict(list)
+
+    # Check semiring
+    if fsa1.R != fsa2.R:
+        mismatches["semiring"].append(f"Semirings do not match: {fsa1.R} != {fsa2.R}")
+
+    # Check input and output alphabets
+    if fsa1.Sigma != fsa2.Sigma:
+        mismatches["alphabet"].append(
+            f"Input alphabets do not match: {fsa1.Sigma} != {fsa2.Sigma}"
+        )
+    if isinstance(fsa1, FST) and isinstance(fsa2, FST) and fsa1.Delta != fsa2.Delta:
+        mismatches["alphabet"].append(
+            f"Output alphabets do not match: {fsa1.Delta} != {fsa2.Delta}"
+        )
+
+    # Check states set equality. We want to report the following:
+    # - States in fst1 but not in fst2
+    # - States in fst2 but not in fst1
+    missing_states1 = fsa1.Q - fsa2.Q
+    missing_states2 = fsa2.Q - fsa1.Q
+    if len(missing_states1) > 0:
+        mismatches["states"].append(
+            f"States in FST1 but not in FST2: {missing_states1}"
+        )
+    if len(missing_states2) > 0:
+        mismatches["states"].append(
+            f"States in FST2 but not in FST1: {missing_states2}"
+        )
+
+    # Check initial and final weights. The weight functions λ and ρ must be functionally equal, i.e.
+    # agree on every value on the domain (all states).
+    for q in fsa1.Q:
+        if fsa1.λ[q] != fsa2.λ[q]:
+            mismatches["state_weights"].append(
+                f"Initial weight for state {q} does not match: {fsa1.λ[q]} != {fsa2.λ[q]}"
+            )
+        if fsa1.ρ[q] != fsa2.ρ[q]:
+            mismatches["state_weights"].append(
+                f"Final weight for state {q} does not match: {fsa1.ρ[q]} != {fsa2.ρ[q]}"
+            )
+
+    # Check arcs. We first flatten the arcs into a list of tuples (i, (a, b), j, w) and compare.
+    # We report:
+    # - Missing arcs (i, (a, b), j) in FST1
+    # - Missing arcs (i, (a, b), j) in FST2
+    # - Mismatching weights
+    arcs1 = _arcs(fsa1)
+    arcs2 = _arcs(fsa2)
+
+    def _unweighted(arcs):
+        return {(i, ab, j) for i, ab, j, _ in arcs}
+
+    missing_arcs1 = _unweighted(arcs2) - _unweighted(arcs1)
+    missing_arcs2 = _unweighted(arcs1) - _unweighted(arcs2)
+    if len(missing_arcs1) > 0:
+        mismatches["arcs"].append(f"Missing arcs in FST1: {missing_arcs1}")
+    if len(missing_arcs2) > 0:
+        mismatches["arcs"].append(f"Missing arcs in FST2: {missing_arcs2}")
+
+    def _arc_weight_mismatch(arcs1, arcs2):
+        return {
+            (tuple(arc1), w1, w2)
+            for *arc1, w1 in arcs1
+            for *arc2, w2 in arcs2
+            if arc1 == arc2 and w1 != w2
+        }
+
+    arc_weight_mismatches = _arc_weight_mismatch(arcs1, arcs2)
+    for arc, w1, w2 in arc_weight_mismatches:
+        mismatches["arc_weights"].append(
+            f"Weight for arc {arc} does not match: {w1} != {w2}"
+        )
+
+    return _FSAStructuralEqualityReport(mismatches, title=title)
+
+
+def fsa_structurally_equal(fsa1: FSA | FST, fsa2: FSA | FST):
+    """
+    Returns True if the two FSTs are structurally equal, False otherwise. See
+    `report_fst_structural_equality` for more details.
+
+    Args:
+        fsa1 (FSA | FST): First FSA
+        fsa2 (FSA | FST): Second FSA
+
+    Returns:
+        bool: True if the two FSTs are structurally equal, False otherwise.
+    """
+    return fsa_structural_equality_report(fsa1, fsa2).structurally_equal

--- a/rayuela/fsa/fsa_testing.py
+++ b/rayuela/fsa/fsa_testing.py
@@ -122,9 +122,9 @@ def fsa_structural_equality_report(fsa1: FSA | FST, fsa2: FSA | FST, title=None)
         mismatches["alphabet"].append(
             f"Input alphabets do not match: {fsa1.Sigma} != {fsa2.Sigma}"
         )
-    if isinstance(fsa1, FST) and isinstance(fsa2, FST) and fsa1.Delta != fsa2.Delta:
+    if isinstance(fsa1, FST) and isinstance(fsa2, FST) and fsa1.Omega != fsa2.Omega:
         mismatches["alphabet"].append(
-            f"Output alphabets do not match: {fsa1.Delta} != {fsa2.Delta}"
+            f"Output alphabets do not match: {fsa1.Omega} != {fsa2.Omega}"
         )
 
     # Check states set equality. We want to report the following:

--- a/rayuela/fsa/fst.py
+++ b/rayuela/fsa/fst.py
@@ -36,7 +36,7 @@ class FST(FSA):
         super().__init__(R=R)
 
         # alphabet of output symbols
-        self.Delta = set()
+        self.Omega = set()
 
     def add_arc(self, i, a, b, j, w=None):
         if w is None: w = self.R.one
@@ -49,7 +49,7 @@ class FST(FSA):
 
         self.add_states([i, j])
         self.Sigma.add(a)
-        self.Delta.add(b)
+        self.Omega.add(b)
         self.δ[i][(a, b)][j] += w
 
     def set_arc(self, i, a, b, j, w=None):
@@ -63,12 +63,12 @@ class FST(FSA):
 
         self.add_states([i, j])
         self.Sigma.add(a)
-        self.Delta.add(b)
+        self.Omega.add(b)
         self.δ[i][(a, b)][j] = w
 
     def freeze(self):
         self.Sigma = frozenset(self.Sigma)
-        self.Delta = frozenset(self.Delta)
+        self.Omega = frozenset(self.Omega)
         self.Q = frozenset(self.Q)
         self.δ = frozendict(self.δ)
         self.λ = frozendict(self.λ)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ install_requires = [
     "frozenlist",
     "pyconll",
     "nltk",
+    "tabulate",  # Table pretty printing
 
     # Libraries used for testing
     "pytest",

--- a/tests/test_fsa_structural_equality.py
+++ b/tests/test_fsa_structural_equality.py
@@ -1,5 +1,3 @@
-import unittest
-
 from rayuela.base.semiring import Boolean, Real
 from rayuela.base.symbol import Sym, ε
 from rayuela.fsa.fsa import FSA, State
@@ -83,37 +81,38 @@ def _make_fst2():
     return fst
 
 
-class TestFsaStructuralEqualityReport(unittest.TestCase):
-    def setUp(self):
-        # Create instances of FSA or FST for testing
-        self.fsa1 = _make_fsa1()
-        self.fsa2 = _make_fsa2()
-        self.fst1 = _make_fst1()
-        self.fst2 = _make_fst2()
-
-    def test_commutativity(self):
-        report1 = fsa_structural_equality_report(self.fsa1, self.fsa2)
-        report2 = fsa_structural_equality_report(self.fsa2, self.fsa1)
-        self.assertEqual(report1.structurally_equal, report2.structurally_equal)
-
-    def test_fsa_structural_equality(self):
-        report = fsa_structural_equality_report(self.fsa1, self.fsa2)
-        self.assertFalse(report.structurally_equal)
-
-        report = fsa_structural_equality_report(self.fsa1, self.fsa1)
-        self.assertTrue(report.structurally_equal)
-
-    def test_fst_structural_equality(self):
-        report = fsa_structural_equality_report(self.fst1, self.fst2)
-        self.assertFalse(report.structurally_equal)
-
-        report = fsa_structural_equality_report(self.fst1, self.fst1)
-        self.assertTrue(report.structurally_equal)
-
-    def test_fsa_fst_structural_inequality(self):
-        report = fsa_structural_equality_report(self.fsa1, self.fst1)
-        self.assertFalse(report.structurally_equal)
+# Create instances of FSA or FST for testing
+fsa1 = _make_fsa1()
+fsa2 = _make_fsa2()
+fst1 = _make_fst1()
+fst2 = _make_fst2()
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_commutativity():
+    report1 = fsa_structural_equality_report(fsa1, fsa2)
+    report2 = fsa_structural_equality_report(fsa2, fsa1)
+    assert report1.structurally_equal == report2.structurally_equal
+
+
+def test_fsa_structural_equality():
+    report = fsa_structural_equality_report(fsa1, fsa2)
+    assert not report.structurally_equal
+
+    # Just for visualization
+    print(report)
+
+    report = fsa_structural_equality_report(fsa1, fsa1)
+    assert report.structurally_equal
+
+
+def test_fst_structural_equality():
+    report = fsa_structural_equality_report(fst1, fst2)
+    assert not report.structurally_equal
+
+    report = fsa_structural_equality_report(fst1, fst1)
+    assert report.structurally_equal
+
+
+def test_fsa_fst_structural_inequality():
+    report = fsa_structural_equality_report(fsa1, fst1)
+    assert not report.structurally_equal

--- a/tests/test_fsa_structural_equality.py
+++ b/tests/test_fsa_structural_equality.py
@@ -1,0 +1,119 @@
+import unittest
+
+from rayuela.base.semiring import Boolean, Real
+from rayuela.base.symbol import Sym, ε
+from rayuela.fsa.fsa import FSA, State
+from rayuela.fsa.fsa_testing import fsa_structural_equality_report
+from rayuela.fsa.fst import FST
+
+
+def _make_fsa1():
+    fsa = FSA(R=Boolean)
+
+    fsa.add_states({State(i) for i in [0, 1, 2]})
+    fsa.set_I(State(0), Boolean(True))
+    fsa.set_F(State(2), Boolean(True))
+
+    fsa.add_arc(State(0), ε, State(0), Boolean(True))
+    fsa.add_arc(State(0), Sym("b"), State(0), Boolean(True))
+    fsa.add_arc(State(0), Sym("c"), State(0), Boolean(True))
+    fsa.add_arc(State(0), Sym("a"), State(2), Boolean(True))
+    fsa.add_arc(State(2), Sym("a"), State(0), Boolean(True))
+    fsa.add_arc(State(1), Sym("a"), State(0), Boolean(True))
+    fsa.add_arc(State(2), Sym("c"), State(1), Boolean(True))
+    fsa.add_arc(State(1), ε, State(2), Boolean(True))
+    fsa.add_arc(State(1), Sym("b"), State(2), Boolean(True))
+    fsa.add_arc(State(1), Sym("c"), State(2), Boolean(True))
+
+    return fsa
+
+
+def _make_fsa2():
+    fsa = FSA(R=Boolean)
+
+    fsa.add_states({State(i) for i in [0, 1, 2, 3]})
+    fsa.set_I(State(0), Boolean(True))
+    fsa.set_F(State(2), Boolean(True))
+
+    fsa.add_arc(State(0), ε, State(0), Boolean(True))
+    fsa.add_arc(State(0), Sym("c"), State(0), Boolean(True))
+    fsa.add_arc(State(0), Sym("a"), State(2), Boolean(True))
+    fsa.add_arc(State(2), Sym("a"), State(0), Boolean(False))
+    fsa.add_arc(State(1), Sym("a"), State(0), Boolean(True))
+    fsa.add_arc(State(2), Sym("c"), State(1), Boolean(True))
+    fsa.add_arc(State(1), ε, State(2), Boolean(True))
+    fsa.add_arc(State(1), Sym("b"), State(2), Boolean(True))
+    fsa.add_arc(State(1), Sym("c"), State(2), Boolean(True))
+    fsa.add_arc(State(1), Sym("d"), State(3), Boolean(True))
+
+    return fsa
+
+
+def _make_fst1():
+    fst = FST(R=Real)
+
+    fst.add_states({State(i) for i in [0, 1]})
+    fst.set_I(State(0), Real(29.0))
+    fst.set_F(State(1), Real(2.0))
+
+    fst.add_arc(State(0), ε, Sym("b"), State(0), Real(0.0))
+    fst.add_arc(State(0), Sym("b"), ε, State(1), Real(35.0))
+    fst.add_arc(State(1), Sym("b"), Sym("b"), State(0), Real(43.0))
+    fst.add_arc(State(1), Sym("a"), Sym("b"), State(0), Real(25.0))
+    fst.add_arc(State(1), ε, Sym("a"), State(1), Real(25.0))
+
+    return fst
+
+
+def _make_fst2():
+    fst = FST(R=Real)
+
+    fst.add_states({State(i) for i in [0, 1, 2]})
+    fst.set_I(State(0), Real(8.0))
+    fst.set_F(State(1), Real(2.5))
+
+    fst.add_arc(State(0), ε, Sym("b"), State(0), Real(0.0))
+    fst.add_arc(State(0), Sym("b"), ε, State(1), Real(35.0))
+    fst.add_arc(State(1), Sym("b"), Sym("b"), State(0), Real(43.1))
+    fst.add_arc(State(1), Sym("a"), Sym("a"), State(0), Real(25.0))
+    fst.add_arc(State(1), ε, Sym("a"), State(1), Real(25.0))
+    fst.add_arc(State(0), Sym("b"), Sym("b"), State(1), Real(35.0))
+    fst.add_arc(State(2), ε, ε, State(2), Real(0.0))
+
+    return fst
+
+
+class TestFsaStructuralEqualityReport(unittest.TestCase):
+    def setUp(self):
+        # Create instances of FSA or FST for testing
+        self.fsa1 = _make_fsa1()
+        self.fsa2 = _make_fsa2()
+        self.fst1 = _make_fst1()
+        self.fst2 = _make_fst2()
+
+    def test_commutativity(self):
+        report1 = fsa_structural_equality_report(self.fsa1, self.fsa2)
+        report2 = fsa_structural_equality_report(self.fsa2, self.fsa1)
+        self.assertEqual(report1.structurally_equal, report2.structurally_equal)
+
+    def test_fsa_structural_equality(self):
+        report = fsa_structural_equality_report(self.fsa1, self.fsa2)
+        self.assertFalse(report.structurally_equal)
+
+        report = fsa_structural_equality_report(self.fsa1, self.fsa1)
+        self.assertTrue(report.structurally_equal)
+
+    def test_fst_structural_equality(self):
+        report = fsa_structural_equality_report(self.fst1, self.fst2)
+        self.assertFalse(report.structurally_equal)
+
+        report = fsa_structural_equality_report(self.fst1, self.fst1)
+        self.assertTrue(report.structurally_equal)
+
+    def test_fsa_fst_structural_inequality(self):
+        report = fsa_structural_equality_report(self.fsa1, self.fst1)
+        self.assertFalse(report.structurally_equal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Students should be able to test their implementation of FST composition. It is really cumbersome to compare the HTML representation of two FSTs by hand, and most students would have to implement the same "boilerplate" testing code themselves. Furthermore, a simple comparison function gives little information about where exactly the mismatch is.

## Proposed Changes

I propose adding a helper function for testing for (structural) FST equality. This function checks all the FST attributes (without checking derived properties like `FST.I`) for equality and returns a printable report with detailed information on the mismatches between two FSTs.

Two FSAs/FSTs are considered equal, if

- They have the same semiring
- They have the same input (and output, if FST) alphabet
- They have the same set of states
- Initial and final weight functions are functionally equal (i.e. agree on every state)
- They have the same set of arcs, and the weight function is functionally equal (i.e. agree on every arc)

## Examples

The return value of the `fsa_structural_equality_report(fsa1, fsa2)` function is a report object, which can either be printed, or its `structurally_equal` attribute can be used to check the truth value. An example report looks as follows:

```
+---------------------------------------------------------------+
| FST Structural Equality Report                                |
+===============================================================+
| Alphabet                                                      |
+---------------------------------------------------------------+
| Input alphabets do not match: {a, b, c, ε} != {a, ε, c, d, b} |
+---------------------------------------------------------------+
| States                                                        |
+---------------------------------------------------------------+
| States in FST2 but not in FST1: {3}                           |
+---------------------------------------------------------------+
| Arcs                                                          |
+---------------------------------------------------------------+
| Missing arcs in FST1: {(1, d, 3)}                             |
| Missing arcs in FST2: {(0, b, 0)}                             |
+---------------------------------------------------------------+
| Arc weights                                                   |
+---------------------------------------------------------------+
| Weight for arc (2, a, 0) does not match: True != False        |
+---------------------------------------------------------------+
```

## Unit Tests

I also added some unit tests to check if the function returns sensible results. The tests are not exhaustive.